### PR TITLE
Add notarized release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,8 @@ jobs:
             fi
           done
           if [[ -z "$APPLE_ID" || -z "$APP_SPECIFIC_PASSWORD" ]]; then
-            if [[ -z "$APP_STORE_CONNECT_API_KEY_BASE64" || -z "$APP_STORE_CONNECT_KEY_ID" ]]; then
-              echo "::error::Set APPLE_ID + APP_SPECIFIC_PASSWORD, or APP_STORE_CONNECT_API_KEY_BASE64 + APP_STORE_CONNECT_KEY_ID (+ APP_STORE_CONNECT_ISSUER_ID for team keys)."
+            if [[ -z "$APP_STORE_CONNECT_API_KEY_BASE64" || -z "$APP_STORE_CONNECT_KEY_ID" || -z "$APP_STORE_CONNECT_ISSUER_ID" ]]; then
+              echo "::error::Set APPLE_ID + APP_SPECIFIC_PASSWORD, or APP_STORE_CONNECT_API_KEY_BASE64 + APP_STORE_CONNECT_KEY_ID + APP_STORE_CONNECT_ISSUER_ID."
               missing=1
             fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,138 @@
+name: Release signed macOS app
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build and upload, for example v1.6.1"
+        required: true
+        type: string
+      update_cask:
+        description: "Update sushaantu/homebrew-cloudflare-status-bar after upload"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build, notarize, and upload
+    runs-on: macos-latest
+
+    steps:
+      - name: Resolve tag
+        id: release_tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+          version="${tag#v}"
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Validate signing secrets
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          missing=0
+          for name in BUILD_CERTIFICATE_BASE64 P12_PASSWORD KEYCHAIN_PASSWORD APPLE_TEAM_ID; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error::$name is required"
+              missing=1
+            fi
+          done
+          if [[ -z "$APPLE_ID" || -z "$APP_SPECIFIC_PASSWORD" ]]; then
+            if [[ -z "$APP_STORE_CONNECT_API_KEY_BASE64" || -z "$APP_STORE_CONNECT_KEY_ID" ]]; then
+              echo "::error::Set APPLE_ID + APP_SPECIFIC_PASSWORD, or APP_STORE_CONNECT_API_KEY_BASE64 + APP_STORE_CONNECT_KEY_ID (+ APP_STORE_CONNECT_ISSUER_ID for team keys)."
+              missing=1
+            fi
+          fi
+          exit "$missing"
+
+      - name: Import Developer ID certificate
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          certificate_path="$RUNNER_TEMP/developer-id-application.p12"
+          keychain_path="$RUNNER_TEMP/app-signing.keychain-db"
+
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode >"$certificate_path"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain_path"
+          security import "$certificate_path" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$keychain_path"
+          security find-identity -v -p codesigning "$keychain_path"
+
+      - name: Build and notarize
+        env:
+          VERSION: ${{ steps.release_tag.outputs.version }}
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          SIGNING_IDENTITY: ${{ secrets.SIGNING_IDENTITY }}
+        run: |
+          if [[ -n "${APP_STORE_CONNECT_API_KEY_BASE64:-}" ]]; then
+            key_path="$RUNNER_TEMP/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
+            echo -n "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode >"$key_path"
+            chmod 600 "$key_path"
+            export APP_STORE_CONNECT_API_KEY_PATH="$key_path"
+          fi
+          scripts/build_release.sh
+
+      - name: Upload release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release_tag.outputs.tag }}
+          VERSION: ${{ steps.release_tag.outputs.version }}
+        run: |
+          asset="dist/CloudflareStatusBar-$VERSION.zip"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" "$asset" --clobber
+          else
+            gh release create "$TAG" "$asset" --title "$TAG" --notes "Signed and notarized macOS release."
+          fi
+
+      - name: Update Homebrew cask
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.release_tag.outputs.version }}
+          ZIP_PATH: dist/CloudflareStatusBar-${{ steps.release_tag.outputs.version }}.zip
+          UPDATE_CASK: ${{ github.event_name == 'push' || inputs.update_cask }}
+        run: |
+          if [[ "$UPDATE_CASK" != "true" ]]; then
+            echo "Skipping Homebrew cask update."
+            exit 0
+          fi
+          if [[ -z "${HOMEBREW_TAP_TOKEN:-}" ]]; then
+            echo "::notice::Skipping Homebrew cask update because HOMEBREW_TAP_TOKEN is not set."
+            exit 0
+          fi
+          scripts/update_homebrew_cask.sh

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Carthage/Build/
 
 # Archives
 *.xcarchive
+dist/
 
 # Playgrounds
 timeline.xctimeline

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ scripts/build_release.sh
 
 Alternatively, set `APPLE_ID` and `APP_SPECIFIC_PASSWORD` instead of `NOTARY_KEYCHAIN_PROFILE`. The script writes `dist/CloudflareStatusBar-<version>.zip`, staples the notarization ticket, runs Gatekeeper assessment, and prints the sha256 for the Homebrew cask.
 
-For App Store Connect API key notarization, set `ASC_KEY_PATH` and `ASC_KEY_ID`; set `ASC_ISSUER_ID` too when using a team key.
+For App Store Connect API key notarization, set `ASC_KEY_PATH`, `ASC_KEY_ID`, and `ASC_ISSUER_ID`.
 
 ### GitHub Actions release build
 
@@ -98,7 +98,7 @@ The `Release signed macOS app` workflow runs for `v*` tags and can also be run m
 - `APP_SPECIFIC_PASSWORD` - App-specific password for notarization
 - `APP_STORE_CONNECT_API_KEY_BASE64` - Base64-encoded App Store Connect `.p8`, when using API key auth instead of app-specific password auth
 - `APP_STORE_CONNECT_KEY_ID` - App Store Connect API key id
-- `APP_STORE_CONNECT_ISSUER_ID` - App Store Connect issuer id, required for team keys
+- `APP_STORE_CONNECT_ISSUER_ID` - App Store Connect issuer id, required for API key auth
 - `SIGNING_IDENTITY` - Optional; defaults to `Developer ID Application`
 - `HOMEBREW_TAP_TOKEN` - Optional token with push access to `sushaantu/homebrew-cloudflare-status-bar`
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,40 @@ Get your API token from: [Cloudflare Dashboard → My Profile → API Tokens](ht
 brew upgrade --cask cloudflare-status-bar
 ```
 
+## Release Signing and Notarization
+
+Homebrew cask installs are quarantined by macOS, so release zip assets must contain a Developer ID signed and notarized app. Ad-hoc signed builds will verify with `codesign`, but Gatekeeper will reject them after download.
+
+### Local release build
+
+```bash
+export TEAM_ID="3LD9A48W2C"
+export NOTARY_KEYCHAIN_PROFILE="cloudflare-status-bar"
+scripts/build_release.sh
+```
+
+Alternatively, set `APPLE_ID` and `APP_SPECIFIC_PASSWORD` instead of `NOTARY_KEYCHAIN_PROFILE`. The script writes `dist/CloudflareStatusBar-<version>.zip`, staples the notarization ticket, runs Gatekeeper assessment, and prints the sha256 for the Homebrew cask.
+
+For App Store Connect API key notarization, set `ASC_KEY_PATH` and `ASC_KEY_ID`; set `ASC_ISSUER_ID` too when using a team key.
+
+### GitHub Actions release build
+
+The `Release signed macOS app` workflow runs for `v*` tags and can also be run manually for an existing tag. Configure these repository secrets before using it:
+
+- `BUILD_CERTIFICATE_BASE64` - Base64-encoded Developer ID Application `.p12`
+- `P12_PASSWORD` - Password for the exported `.p12`
+- `KEYCHAIN_PASSWORD` - Temporary CI keychain password
+- `APPLE_TEAM_ID` - Apple Developer Team ID, for example `3LD9A48W2C`
+- `APPLE_ID` - Apple ID used for notarization, when using app-specific password auth
+- `APP_SPECIFIC_PASSWORD` - App-specific password for notarization
+- `APP_STORE_CONNECT_API_KEY_BASE64` - Base64-encoded App Store Connect `.p8`, when using API key auth instead of app-specific password auth
+- `APP_STORE_CONNECT_KEY_ID` - App Store Connect API key id
+- `APP_STORE_CONNECT_ISSUER_ID` - App Store Connect issuer id, required for team keys
+- `SIGNING_IDENTITY` - Optional; defaults to `Developer ID Application`
+- `HOMEBREW_TAP_TOKEN` - Optional token with push access to `sushaantu/homebrew-cloudflare-status-bar`
+
+To repair a bad existing release asset, run the workflow manually for that tag, for example `v1.6.1`, with cask updating enabled. If the cask token is not configured, update `Casks/cloudflare-status-bar.rb` in the tap with the sha256 printed by the workflow. For normal releases, tag a new version and let the workflow upload the notarized zip and update the cask.
+
 ## Requirements
 
 - macOS 13.0 (Ventura) or later

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="CloudflareStatusBar"
+PROJECT="CloudflareStatusBar.xcodeproj"
+SCHEME="CloudflareStatusBar"
+CONFIGURATION="Release"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd xcodebuild
+require_cmd xcrun
+require_cmd ditto
+require_cmd shasum
+
+VERSION="${VERSION:-}"
+if [[ -z "$VERSION" ]]; then
+  if git describe --tags --exact-match >/dev/null 2>&1; then
+    VERSION="$(git describe --tags --exact-match | sed 's/^v//')"
+  else
+    VERSION="$(
+      xcodebuild -showBuildSettings \
+        -project "$PROJECT" \
+        -scheme "$SCHEME" \
+        -configuration "$CONFIGURATION" 2>/dev/null |
+        awk -F'= ' '/MARKETING_VERSION/ { print $2; exit }'
+    )"
+  fi
+fi
+
+TEAM_ID="${TEAM_ID:-}"
+SIGNING_IDENTITY="${SIGNING_IDENTITY:-Developer ID Application}"
+if [[ -z "$TEAM_ID" ]]; then
+  echo "error: TEAM_ID is required for Developer ID signing" >&2
+  exit 1
+fi
+
+BUILD_ROOT="$REPO_ROOT/build/release"
+ARCHIVE_PATH="$BUILD_ROOT/$APP_NAME.xcarchive"
+EXPORT_PATH="$BUILD_ROOT/export"
+EXPORT_OPTIONS="$BUILD_ROOT/ExportOptions.plist"
+DIST_DIR="$REPO_ROOT/dist"
+APP_PATH="$EXPORT_PATH/$APP_NAME.app"
+NOTARY_ZIP="$BUILD_ROOT/$APP_NAME-notary.zip"
+FINAL_ZIP="$DIST_DIR/$APP_NAME-$VERSION.zip"
+
+rm -rf "$BUILD_ROOT"
+mkdir -p "$BUILD_ROOT" "$DIST_DIR"
+
+cat >"$EXPORT_OPTIONS" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>developer-id</string>
+  <key>signingStyle</key>
+  <string>manual</string>
+  <key>signingCertificate</key>
+  <string>$SIGNING_IDENTITY</string>
+  <key>teamID</key>
+  <string>$TEAM_ID</string>
+  <key>stripSwiftSymbols</key>
+  <true/>
+</dict>
+</plist>
+PLIST
+
+echo "Building $APP_NAME $VERSION with Developer ID signing..."
+xcodebuild archive \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -configuration "$CONFIGURATION" \
+  -archivePath "$ARCHIVE_PATH" \
+  DEVELOPMENT_TEAM="$TEAM_ID" \
+  CODE_SIGN_STYLE=Manual \
+  CODE_SIGN_IDENTITY="$SIGNING_IDENTITY" \
+  OTHER_CODE_SIGN_FLAGS="--timestamp" \
+  clean archive
+
+xcodebuild -exportArchive \
+  -archivePath "$ARCHIVE_PATH" \
+  -exportPath "$EXPORT_PATH" \
+  -exportOptionsPlist "$EXPORT_OPTIONS"
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "error: exported app not found at $APP_PATH" >&2
+  exit 1
+fi
+
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+codesign -dv --verbose=4 "$APP_PATH" 2>&1 | grep -E 'Authority=|TeamIdentifier=|Signature=' || true
+
+if [[ "${SKIP_NOTARIZATION:-0}" == "1" ]]; then
+  echo "warning: SKIP_NOTARIZATION=1; output will not pass Gatekeeper for Homebrew downloads" >&2
+else
+  notary_args=()
+  if [[ -n "${NOTARY_KEYCHAIN_PROFILE:-}" ]]; then
+    notary_args=(--keychain-profile "$NOTARY_KEYCHAIN_PROFILE")
+  elif [[ -n "${ASC_KEY_PATH:-}" || -n "${APP_STORE_CONNECT_API_KEY_PATH:-}" ]]; then
+    key_path="${ASC_KEY_PATH:-${APP_STORE_CONNECT_API_KEY_PATH:-}}"
+    key_id="${ASC_KEY_ID:-${APP_STORE_CONNECT_KEY_ID:-}}"
+    issuer_id="${ASC_ISSUER_ID:-${APP_STORE_CONNECT_ISSUER_ID:-}}"
+    if [[ -z "$key_id" ]]; then
+      echo "error: set ASC_KEY_ID or APP_STORE_CONNECT_KEY_ID for API key notarization" >&2
+      exit 1
+    fi
+    notary_args=(--key "$key_path" --key-id "$key_id")
+    if [[ -n "$issuer_id" ]]; then
+      notary_args+=(--issuer "$issuer_id")
+    fi
+  else
+    if [[ -z "${APPLE_ID:-}" || -z "${APP_SPECIFIC_PASSWORD:-}" ]]; then
+      echo "error: set NOTARY_KEYCHAIN_PROFILE, App Store Connect API key vars, or APPLE_ID and APP_SPECIFIC_PASSWORD for notarization" >&2
+      exit 1
+    fi
+    notary_args=(--apple-id "$APPLE_ID" --password "$APP_SPECIFIC_PASSWORD" --team-id "$TEAM_ID")
+  fi
+
+  echo "Submitting $APP_NAME for notarization..."
+  rm -f "$NOTARY_ZIP"
+  ditto -c -k --keepParent --norsrc --noextattr --noqtn --noacl "$APP_PATH" "$NOTARY_ZIP"
+  xcrun notarytool submit "$NOTARY_ZIP" --wait "${notary_args[@]}"
+  xcrun stapler staple "$APP_PATH"
+  xcrun stapler validate "$APP_PATH"
+  spctl --assess --type execute --verbose=4 "$APP_PATH"
+fi
+
+rm -f "$FINAL_ZIP"
+ditto -c -k --keepParent --norsrc --noextattr --noqtn --noacl "$APP_PATH" "$FINAL_ZIP"
+
+SHA256="$(shasum -a 256 "$FINAL_ZIP" | awk '{ print $1 }')"
+echo "Created $FINAL_ZIP"
+echo "sha256: $SHA256"

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -24,17 +24,22 @@ require_cmd shasum
 
 VERSION="${VERSION:-}"
 if [[ -z "$VERSION" ]]; then
-  if git describe --tags --exact-match >/dev/null 2>&1; then
-    VERSION="$(git describe --tags --exact-match | sed 's/^v//')"
+  if TAG="$(git describe --tags --exact-match 2>/dev/null)"; then
+    VERSION="${TAG#v}"
   else
     VERSION="$(
       xcodebuild -showBuildSettings \
         -project "$PROJECT" \
         -scheme "$SCHEME" \
         -configuration "$CONFIGURATION" 2>/dev/null |
-        awk -F'= ' '/MARKETING_VERSION/ { print $2; exit }'
+        awk '/MARKETING_VERSION/ { print $3; exit }'
     )"
   fi
+fi
+
+if [[ -z "$VERSION" ]]; then
+  echo "error: failed to determine VERSION" >&2
+  exit 1
 fi
 
 TEAM_ID="${TEAM_ID:-}"
@@ -110,14 +115,19 @@ else
     key_path="${ASC_KEY_PATH:-${APP_STORE_CONNECT_API_KEY_PATH:-}}"
     key_id="${ASC_KEY_ID:-${APP_STORE_CONNECT_KEY_ID:-}}"
     issuer_id="${ASC_ISSUER_ID:-${APP_STORE_CONNECT_ISSUER_ID:-}}"
+    if [[ ! -f "$key_path" ]]; then
+      echo "error: API key file not found at $key_path" >&2
+      exit 1
+    fi
     if [[ -z "$key_id" ]]; then
       echo "error: set ASC_KEY_ID or APP_STORE_CONNECT_KEY_ID for API key notarization" >&2
       exit 1
     fi
-    notary_args=(--key "$key_path" --key-id "$key_id")
-    if [[ -n "$issuer_id" ]]; then
-      notary_args+=(--issuer "$issuer_id")
+    if [[ -z "$issuer_id" ]]; then
+      echo "error: set ASC_ISSUER_ID or APP_STORE_CONNECT_ISSUER_ID for API key notarization" >&2
+      exit 1
     fi
+    notary_args=(--key "$key_path" --key-id "$key_id" --issuer "$issuer_id")
   else
     if [[ -z "${APPLE_ID:-}" || -z "${APP_SPECIFIC_PASSWORD:-}" ]]; then
       echo "error: set NOTARY_KEYCHAIN_PROFILE, App Store Connect API key vars, or APPLE_ID and APP_SPECIFIC_PASSWORD for notarization" >&2

--- a/scripts/update_homebrew_cask.sh
+++ b/scripts/update_homebrew_cask.sh
@@ -24,9 +24,11 @@ if [[ -z "$SHA256" ]]; then
   SHA256="$(shasum -a 256 "$ZIP_PATH" | awk '{ print $1 }')"
 fi
 
-WORK_ROOT="${RUNNER_TEMP:-}"
-if [[ -z "$WORK_ROOT" ]]; then
+if [[ -z "${RUNNER_TEMP:-}" ]]; then
   WORK_ROOT="$(mktemp -d)"
+  trap 'rm -rf "$WORK_ROOT"' EXIT
+else
+  WORK_ROOT="$RUNNER_TEMP"
 fi
 TAP_DIR="$WORK_ROOT/homebrew-cloudflare-status-bar"
 

--- a/scripts/update_homebrew_cask.sh
+++ b/scripts/update_homebrew_cask.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="CloudflareStatusBar"
+TAP_REPO="${TAP_REPO:-sushaantu/homebrew-cloudflare-status-bar}"
+TAP_BRANCH="${TAP_BRANCH:-main}"
+VERSION="${VERSION:-}"
+ZIP_PATH="${ZIP_PATH:-}"
+SHA256="${SHA256:-}"
+
+if [[ -z "$VERSION" ]]; then
+  echo "error: VERSION is required" >&2
+  exit 1
+fi
+
+if [[ -z "$SHA256" ]]; then
+  if [[ -z "$ZIP_PATH" ]]; then
+    ZIP_PATH="dist/$APP_NAME-$VERSION.zip"
+  fi
+  if [[ ! -f "$ZIP_PATH" ]]; then
+    echo "error: ZIP_PATH does not exist: $ZIP_PATH" >&2
+    exit 1
+  fi
+  SHA256="$(shasum -a 256 "$ZIP_PATH" | awk '{ print $1 }')"
+fi
+
+WORK_ROOT="${RUNNER_TEMP:-}"
+if [[ -z "$WORK_ROOT" ]]; then
+  WORK_ROOT="$(mktemp -d)"
+fi
+TAP_DIR="$WORK_ROOT/homebrew-cloudflare-status-bar"
+
+rm -rf "$TAP_DIR"
+if [[ -n "${HOMEBREW_TAP_TOKEN:-}" ]]; then
+  git clone "https://x-access-token:$HOMEBREW_TAP_TOKEN@github.com/$TAP_REPO.git" "$TAP_DIR"
+else
+  git clone "https://github.com/$TAP_REPO.git" "$TAP_DIR"
+fi
+
+cd "$TAP_DIR"
+git checkout "$TAP_BRANCH"
+
+CASK_FILE="Casks/cloudflare-status-bar.rb"
+if [[ ! -f "$CASK_FILE" ]]; then
+  echo "error: cask file not found: $CASK_FILE" >&2
+  exit 1
+fi
+
+VERSION="$VERSION" SHA256="$SHA256" ruby -0pi -e '
+  gsub(/version "[^"]+"/, "version \"#{ENV.fetch("VERSION")}\"")
+  gsub(/sha256 "[^"]+"/, "sha256 \"#{ENV.fetch("SHA256")}\"")
+' "$CASK_FILE"
+
+if git diff --quiet -- "$CASK_FILE"; then
+  echo "Homebrew cask already points at $VERSION ($SHA256)"
+  exit 0
+fi
+
+git config user.name "${GIT_AUTHOR_NAME:-github-actions[bot]}"
+git config user.email "${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+git add "$CASK_FILE"
+git commit -m "Update CloudflareStatusBar to $VERSION"
+git push origin "HEAD:$TAP_BRANCH"


### PR DESCRIPTION
## Summary
- add a local Developer ID signing/notarization release script
- add a tag/manual GitHub Actions workflow that imports signing material, notarizes, uploads the release zip, and can update the Homebrew tap
- document the required signing and App Store Connect secrets

## Verification
- Replaced v1.6.1 release asset with a Developer ID signed, stapled, notarized zip
- Updated Homebrew tap checksum to 8e360053685879aee292ec614ac7b0ac7e0096a50e3091c378800ec40aded54e
- Fresh GitHub release download: sha256 matched cask
- Fresh unzip: appledouble_files=0
- codesign --verify --deep --strict passed
- xcrun stapler validate passed
- spctl --assess --type execute returned accepted, source=Notarized Developer ID
- bash -n scripts/build_release.sh scripts/update_homebrew_cask.sh
- workflow YAML parsed with Ruby YAML
- git diff --cached --check passed